### PR TITLE
Enable custom workspaces

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -104,12 +104,20 @@ attributes:
   custom_sif:
     label: Full path to your customized code-server Apptainer image.
     help: "e.g. /mmfs1/gscratch/labname/containers/code-server.sif"
+  working_dir:
+    label: "Working Directory"
+    data-filepicker: true
+    data-target-file-type: dirs
+    readonly: false
+    help: |
+      Home for your workspace: holds extensions, data, and files. Defaults to $HOME if left empty.
 
 form:
   - haccount
   - hqueue
   - sif
   - custom_sif
+  - working_dir
   - htasks
   - hcpus
   - hmem

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -110,7 +110,14 @@ attributes:
     data-target-file-type: dirs
     readonly: false
     help: |
-      Home for your workspace: holds extensions, data, and files. Defaults to $HOME if left empty.
+      Project's root folder. Defaults to $HOME if left empty.
+  data_dir:
+    label: "Data/Extensions Directory"
+    data-filepicker: true
+    data-target-file-type: dirs
+    readonly: false
+    help: |
+      Alternate storage location for your workspace extensions and data. Defaults to $HOME if left empty.
 
 form:
   - haccount
@@ -118,6 +125,7 @@ form:
   - sif
   - custom_sif
   - working_dir
+  - data_dir
   - htasks
   - hcpus
   - hmem

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -3,6 +3,7 @@
 <%
 # Set our working directory.
 working_dir = Pathname.new(context.working_dir)
+data_dir = Pathname.new(context.data_dir)
 
 # Ensure that code-server always starts up in either a user defined directory or the home directory.
 if !working_dir.exist?
@@ -10,10 +11,17 @@ if !working_dir.exist?
 elsif working_dir.file?
     working_dir = working_dir.parent
 end
+
+# Data directory is $HOME by default.
+if !data_dir.exist?
+    data_dir = Pathname.new(ENV['HOME'])
+elsif data_dir.file?
+    data_dir = data_dir.parent
+end
 %>
 
 # Create config file for code-server
-cat > <%= working_dir %>/.config/code-server/config.yaml <<END
+cat > ${HOME}/.config/code-server/config.yaml <<END
 bind-addr: 127.0.0.1:8080
 auth: password
 password: ${password}
@@ -21,7 +29,7 @@ cert: false
 END
 
 # Set working directory as default
-cat > <%= working_dir %>/.local/share/code-server/coder.json <<END
+cat > ${HOME}/.local/share/code-server/coder.json <<END
 {
   "query": {
     "folder": "<%= working_dir %>"
@@ -29,7 +37,7 @@ cat > <%= working_dir %>/.local/share/code-server/coder.json <<END
 }
 END
 
-# Configure SSH in VS Code
+# Set up working directory terminal to launch on node
 mkdir -p <%= working_dir %>/.vscode
 cat > <%= working_dir %>/.vscode/settings.json <<END
 {
@@ -42,7 +50,7 @@ cat > <%= working_dir %>/.vscode/settings.json <<END
                 "localhost",
             ]
         },
-    }
+    },
     "terminal.integrated.defaultProfile.linux": "apptainer"
 }
 END
@@ -51,9 +59,12 @@ END
 echo "Starting code-server..."
 export PASSWORD=${password}
 
-apptainer exec --cleanenv --home <%= working_dir %> ${CODESERVER_APPTAINER_IMAGE} \
+apptainer exec --cleanenv --home ${HOME} ${CODESERVER_APPTAINER_IMAGE} \
     /app/code-server/bin/code-server \
     --bind-addr=${HOSTNAME}:${port} \
+    --user-data-dir="<%= data_dir %>/.local/share/code-server" \
+    --extensions-dir="<%= data_dir %>/.local/share/code-server/extensions" \
     --auth=password \
     --disable-telemetry \
-    --disable-update-check
+    --disable-update-check \
+        "<%= working_dir %>"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -7,14 +7,14 @@ DATA_DIR="<%= context.data_dir %>"
 # Ensure that code-server always starts up in either a user defined directory or the home directory
 if [ ! -e "$WORK_DIR" ]; then
     WORK_DIR="$HOME"
-elif [ -f "$WORK_DIR" ]; then
+elif [ ! -d "$WORK_DIR" ]; then
     WORK_DIR="$(dirname "$WORK_DIR")"
 fi
 
 # Data directory is $HOME by default
 if [ ! -e "$DATA_DIR" ]; then
     DATA_DIR="$HOME"
-elif [ -f "$DATA_DIR" ]; then
+elif [ ! -d "$DATA_DIR" ]; then
     DATA_DIR="$(dirname "$DATA_DIR")"
 fi
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -37,7 +37,7 @@ cat > ${HOME}/.local/share/code-server/coder.json <<END
 }
 END
 
-# Set up working directory terminal to launch on node
+# Configure SSH in VS Code
 mkdir -p <%= working_dir %>/.vscode
 cat > <%= working_dir %>/.vscode/settings.json <<END
 {

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,24 +1,22 @@
 #!/usr/bin/env bash
 
-<%
-# Set our working directory.
-working_dir = Pathname.new(context.working_dir)
-data_dir = Pathname.new(context.data_dir)
+# Set our working directory and data directory variables
+WORK_DIR="<%= context.working_dir %>"
+DATA_DIR="<%= context.data_dir %>"
 
-# Ensure that code-server always starts up in either a user defined directory or the home directory.
-if !working_dir.exist?
-    working_dir = Pathname.new(ENV['HOME'])
-elsif working_dir.file?
-    working_dir = working_dir.parent
-end
+# Ensure that code-server always starts up in either a user defined directory or the home directory
+if [ ! -e "$WORK_DIR" ]; then
+    WORK_DIR="$HOME"
+elif [ -f "$WORK_DIR" ]; then
+    WORK_DIR="$(dirname "$WORK_DIR")"
+fi
 
-# Data directory is $HOME by default.
-if !data_dir.exist?
-    data_dir = Pathname.new(ENV['HOME'])
-elsif data_dir.file?
-    data_dir = data_dir.parent
-end
-%>
+# Data directory is $HOME by default
+if [ ! -e "$DATA_DIR" ]; then
+    DATA_DIR="$HOME"
+elif [ -f "$DATA_DIR" ]; then
+    DATA_DIR="$(dirname "$DATA_DIR")"
+fi
 
 # Create config file for code-server
 cat > ${HOME}/.config/code-server/config.yaml <<END
@@ -32,14 +30,14 @@ END
 cat > ${HOME}/.local/share/code-server/coder.json <<END
 {
   "query": {
-    "folder": "<%= working_dir %>"
+    "folder": "$WORK_DIR"
   }
 }
 END
 
 # Configure SSH in VS Code
-mkdir -p <%= working_dir %>/.vscode
-cat > <%= working_dir %>/.vscode/settings.json <<END
+mkdir -p $WORK_DIR/.vscode
+cat > $WORK_DIR/.vscode/settings.json <<END
 {
     "terminal.integrated.profiles.linux": {
         "apptainer": {
@@ -62,9 +60,9 @@ export PASSWORD=${password}
 apptainer exec --cleanenv --home ${HOME} ${CODESERVER_APPTAINER_IMAGE} \
     /app/code-server/bin/code-server \
     --bind-addr=${HOSTNAME}:${port} \
-    --user-data-dir="<%= data_dir %>/.local/share/code-server" \
-    --extensions-dir="<%= data_dir %>/.local/share/code-server/extensions" \
+    --user-data-dir="$DATA_DIR/.local/share/code-server" \
+    --extensions-dir="$DATA_DIR/.local/share/code-server/extensions" \
     --auth=password \
     --disable-telemetry \
     --disable-update-check \
-        "<%= working_dir %>"
+        "$WORK_DIR"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,24 +1,36 @@
 #!/usr/bin/env bash
 
+<%
+# Set our working directory.
+working_dir = Pathname.new(context.working_dir)
+
+# Ensure that code-server always starts up in either a user defined directory or the home directory.
+if !working_dir.exist?
+    working_dir = Pathname.new(ENV['HOME'])
+elsif working_dir.file?
+    working_dir = working_dir.parent
+end
+%>
+
 # Create config file for code-server
-cat > ${HOME}/.config/code-server/config.yaml <<END
+cat > <%= working_dir %>/.config/code-server/config.yaml <<END
 bind-addr: 127.0.0.1:8080
 auth: password
 password: ${password}
 cert: false
 END
 
-# Set home directory as default
-cat > ${HOME}/.local/share/code-server/coder.json <<END
+# Set working directory as default
+cat > <%= working_dir %>/.local/share/code-server/coder.json <<END
 {
   "query": {
-    "folder": "${HOME}"
+    "folder": "<%= working_dir %>"
   }
 }
 END
 
 # Configure SSH in VS Code
-cat > ${HOME}/.vscode/settings.json <<END
+cat > <%= working_dir %>/.vscode/settings.json <<END
 {
     "terminal.integrated.profiles.linux": {
         "apptainer": {
@@ -38,7 +50,7 @@ END
 echo "Starting code-server..."
 export PASSWORD=${password}
 
-apptainer exec --cleanenv --home ${HOME} ${CODESERVER_APPTAINER_IMAGE} \
+apptainer exec --cleanenv --home <%= working_dir %> ${CODESERVER_APPTAINER_IMAGE} \
     /app/code-server/bin/code-server \
     --bind-addr=${HOSTNAME}:${port} \
     --auth=password \

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -41,7 +41,7 @@ cat > <%= working_dir %>/.vscode/settings.json <<END
                 "localhost",
             ]
         },
-    }
+    },
     "terminal.integrated.defaultProfile.linux": "apptainer"
 }
 END

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -30,6 +30,7 @@ cat > <%= working_dir %>/.local/share/code-server/coder.json <<END
 END
 
 # Configure SSH in VS Code
+mkdir -p <%= working_dir %>/.vscode
 cat > <%= working_dir %>/.vscode/settings.json <<END
 {
     "terminal.integrated.profiles.linux": {
@@ -41,7 +42,7 @@ cat > <%= working_dir %>/.vscode/settings.json <<END
                 "localhost",
             ]
         },
-    },
+    }
     "terminal.integrated.defaultProfile.linux": "apptainer"
 }
 END

--- a/view.html.erb
+++ b/view.html.erb
@@ -15,6 +15,6 @@
   <input type="hidden" name="appUri" value="">
   <input id="csrfToken" type="hidden" name="csrf-token" value="<%= csrftoken %>"/>
   <button class="btn btn-primary" type="submit">
-    <i class="fa fa-registered"></i> Connect to VS Code Server
+    <i class="fa fa-code"></i> Connect to VS Code Server
   </button>
 </form>


### PR DESCRIPTION
## Changes
- Add option to set a working directory. This should enable a workflow better than always `cd`ing into a symlink.
- Add an option to use an alternate data/extensions directory to reduce the load of code-server on user's home directory quota. 
  - Just a few extensions can bump up usage to ~2GB.
- Bug fix: `cat >` creates files but not directories, which was leading a configuration failure. It seems like for all other occurrences, the directories already existed. However, adding settings to automatically `ssh localhost` would fail if `.vscode/` was not already in the home directory. I create the directory before the cat to ensure the settings file is created and opening a terminal correctly opens to the node and not the container.
- Update launch icon to be cooler code design and not rstudio's


## Tests
- Tested with and without custom directories to ensure the $HOME default works correctly. Configuration when using different data dirs is correctly independent. Terminals launch correctly on the node regardless of working/data directory.


## TODO
- Launching a terminal opens at $HOME and not the working directory. Worth changing or is this desired behavior?
- I'll be writing OOD documentation for this soon.


## Questions
- We put the `config.yaml` file with the password in $HOME. If two instances write to this at the same time won't we have an issue?